### PR TITLE
Various fixes, attempt 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,15 +49,16 @@ target_link_libraries(app ${SDL2_LIBRARY})
 add_library(Catch INTERFACE)
 target_include_directories(Catch INTERFACE "lib/")
 
-add_executable(catch_test test/main.cpp 
+add_executable(catch_test test/main.cpp
   ${PROJECT_SRCS}
   test/test_util.cpp
   test/vector_test.cpp
-  test/polygon_test.cpp)
+  test/polygon_test.cpp
+  test/mrb_wrapper.cpp)
 
 
 target_link_libraries(catch_test Catch)
-target_linK_libraries(catch_test 
+target_linK_libraries(catch_test
   ${CMAKE_SOURCE_DIR}/mruby/build/host/lib/libmruby.a)
 
 add_test(NAME CatchTests COMMAND catch_test)

--- a/include/mrb_wrapper.hpp
+++ b/include/mrb_wrapper.hpp
@@ -233,7 +233,6 @@ namespace NM::mrb {
 
     template<typename T>
     typename std::enable_if<traits::is_shared_native<typename std::remove_reference<typename std::remove_pointer<T>::type>::type>::value>::type conversion_check(mrb_state *mrb, mrb_value val) {
-        using Ti = typename std::remove_reference<typename std::remove_pointer<T>::type>::type;
         auto type = data_type<T>::value();
 
         if(mrb_type(val) != MRB_TT_DATA) {

--- a/include/mrb_wrapper.hpp
+++ b/include/mrb_wrapper.hpp
@@ -347,6 +347,9 @@ namespace NM::mrb {
     template<typename ...Args>
     const char param_format_string<Args...>::value[] = {(param_char<typename std::remove_reference<Args>::type>::value)..., '\0'};
 
+    template<typename ...Args>
+    constexpr auto param_format_string_v = param_format_string<Args...>::value;
+
     /**
      Defines a struct that assists in conversion of types from mruby types to C++ types.
      */
@@ -509,7 +512,7 @@ namespace NM::mrb {
 
         private:
             static mrb_value val(mrb_state *mrb, mrb_value self) {
-                std::string format = param_format_string<Args...>::value;
+                std::string format = param_format_string_v<Args...>;
                 std::tuple<conversion_helper<Args>...> t;
                 translator<T>::fill_tuple(format, mrb, t, std::index_sequence_for<Args...>{});
                 translator<T>::fill_mrb_values(mrb, t, std::index_sequence_for<Args...>{});
@@ -539,7 +542,7 @@ namespace NM::mrb {
 
             private:
                 static mrb_value method(mrb_state *mrb, mrb_value self) {
-                    std::string format = param_format_string<Args...>::value;
+                    std::string format = param_format_string_v<Args...>;
                     std::tuple<conversion_helper<Args>...> t;
                     fill_tuple(format, mrb, t, std::index_sequence_for<Args...>{});
                     fill_mrb_values(mrb, t, std::index_sequence_for<Args...>{});
@@ -565,7 +568,7 @@ namespace NM::mrb {
 
             private:
                 static mrb_value method(mrb_state *mrb, mrb_value self) {
-                    std::string format = param_format_string<Args...>::value;
+                    std::string format = param_format_string_v<Args...>;
                     std::tuple<conversion_helper<Args>...> t;
                     fill_tuple(format, mrb, t, std::index_sequence_for<Args...>{});
                     fill_mrb_values(mrb, t, std::index_sequence_for<Args...>{});

--- a/include/mrb_wrapper.hpp
+++ b/include/mrb_wrapper.hpp
@@ -248,6 +248,19 @@ namespace NM::mrb {
         }
     }
 
+    template<>
+    inline bool from_value<bool>(mrb_state *mrb, mrb_value val) {
+        switch (mrb_type(val)) {
+            case MRB_TT_TRUE:
+            case MRB_TT_FALSE:
+                return mrb_bool(val);
+
+            default:
+                auto q = std::string{"Expected a bool, received a "} + data_type_string(val);
+                throw BadValueConversion{q};
+        }
+    }
+
     template<typename T>
     typename std::enable_if<traits::is_shared_native_v<typename std::remove_reference<typename std::remove_pointer<T>::type>::type>>::type conversion_check(mrb_state *mrb, mrb_value val) {
         auto type = data_type<T>::value();

--- a/include/mrb_wrapper.hpp
+++ b/include/mrb_wrapper.hpp
@@ -146,11 +146,12 @@ namespace NM::mrb {
 
 
     template<typename T>
-    inline typename std::enable_if<std::is_integral<T>::value && ! std::is_same<bool, T>::value, mrb_value>::type to_value(mrb_state *mrb, T i) {
+    inline typename std::enable_if<std::is_integral<T>::value, mrb_value>::type to_value(mrb_state *mrb, T i) {
         return mrb_fixnum_value(i);
     }
 
-    inline mrb_value to_value(mrb_state *mrb, bool b) {
+    template<>
+    inline mrb_value to_value<bool>(mrb_state *mrb, bool b) {
         return mrb_bool_value(b);
     }
 
@@ -319,13 +320,13 @@ namespace NM::mrb {
 
     // i is for integer
     template<typename T>
-    struct param_char<T, typename std::enable_if<std::is_integral<T>::value && ! std::is_same<bool, T>::value>::type> {
+    struct param_char<T, typename std::enable_if<std::is_integral<T>::value>::type> {
         constexpr static auto value = 'i';
     };
 
     // b is for bool
-    template<typename T>
-    struct param_char<T, typename std::enable_if<std::is_same<bool, T>::value>::type> {
+    template<>
+    struct param_char<bool> {
         constexpr static auto value = 'b';
     };
 

--- a/include/mrb_wrapper.hpp
+++ b/include/mrb_wrapper.hpp
@@ -65,6 +65,12 @@ namespace NM::mrb {
             constexpr static bool value = std::is_same<const struct mrb_data_type, T>::value;
         };
 
+        /**
+         @brief Helper variable template for is_data_type_struct.
+         */
+        template<typename T>
+        constexpr bool is_data_type_struct_v = is_data_type_struct<T>::value;
+
 
         /**
          @brief determine if a user-defined object can be shared with MRB
@@ -90,7 +96,7 @@ namespace NM::mrb {
          */
         template<typename T>
         struct is_shared_native <T,
-        typename std::enable_if<is_data_type_struct<decltype(T::mrb_type)>::value>::type> {
+        typename std::enable_if<is_data_type_struct_v<decltype(T::mrb_type)>>::type> {
             constexpr static bool value = true;
         };
         /**
@@ -98,12 +104,18 @@ namespace NM::mrb {
          */
 
         /**
+         @brief Helper variable template for is_shared_native.
+         */
+        template<typename T>
+        constexpr bool is_shared_native_v = is_shared_native<T>::value;
+
+        /**
          Type trait which determines if this is any type we can share with MRB, including primitive types
          such as mrb_float, mrb_bool, and so on.
          */
         template<typename T>
         struct is_convertable {
-            constexpr static bool value = (is_shared_native<T>::value
+            constexpr static bool value = (is_shared_native_v<T>
                                            || std::is_integral<T>::value
                                            || std::is_same<bool, T>::value
                                            || std::is_floating_point<T>::value
@@ -111,7 +123,11 @@ namespace NM::mrb {
                                            || std::is_same<const char*, T>::value);
         };
 
-
+        /**
+         @brief Helper variable template for is_convertable.
+         */
+        template<typename T>
+        constexpr bool is_convertable_v = is_convertable<T>::value;
     }
 
     /**
@@ -122,7 +138,7 @@ namespace NM::mrb {
     struct data_type {
         static const mrb_data_type* value() {
             using rt = typename std::remove_reference<typename std::remove_pointer<T>::type>::type;
-            static_assert(traits::is_shared_native<rt>::value,
+            static_assert(traits::is_shared_native_v<rt>,
                           "Can't get an MRB data type for a non-MRB object");
             return &(std::remove_reference<rt>::type::mrb_type);
         }
@@ -155,7 +171,7 @@ namespace NM::mrb {
      That is going to change soon, hopefulyl!
      */
     template<typename T>
-    typename std::enable_if<traits::is_shared_native<T>::value && std::is_copy_constructible<T>::value, mrb_value>::type to_value(mrb_state *mrb, T obj) {
+    typename std::enable_if<traits::is_shared_native_v<T> && std::is_copy_constructible<T>::value, mrb_value>::type to_value(mrb_state *mrb, T obj) {
         const mrb_data_type *type = data_type<T>::value();
         struct RClass* klass = mrb_class_get(mrb, type->struct_name);
         // We create a copy here
@@ -164,7 +180,7 @@ namespace NM::mrb {
     }
 
     template<typename T>
-    typename std::enable_if<traits::is_shared_native<typename std::remove_pointer<T>::type>::value &&
+    typename std::enable_if<traits::is_shared_native_v<typename std::remove_pointer<T>::type> &&
     std::is_pointer<T>::value, mrb_value>::type to_value
     (mrb_state *mrb, T obj) {
         const mrb_data_type *type = data_type<typename std::remove_pointer<T>::type>::value();
@@ -232,7 +248,7 @@ namespace NM::mrb {
     }
 
     template<typename T>
-    typename std::enable_if<traits::is_shared_native<typename std::remove_reference<typename std::remove_pointer<T>::type>::type>::value>::type conversion_check(mrb_state *mrb, mrb_value val) {
+    typename std::enable_if<traits::is_shared_native_v<typename std::remove_reference<typename std::remove_pointer<T>::type>::type>>::type conversion_check(mrb_state *mrb, mrb_value val) {
         auto type = data_type<T>::value();
 
         if(mrb_type(val) != MRB_TT_DATA) {
@@ -252,7 +268,7 @@ namespace NM::mrb {
 
     template<typename T>
     typename std::enable_if<std::is_pointer<T>::value &&
-    traits::is_shared_native<typename std::remove_pointer<T>::type>::value, T>::type
+    traits::is_shared_native_v<typename std::remove_pointer<T>::type>, T>::type
     from_value(mrb_state *mrb, mrb_value val) {
         const mrb_data_type *type = data_type<T>::value();
         conversion_check<T>(mrb, val);
@@ -262,7 +278,7 @@ namespace NM::mrb {
 
     template<typename T>
     typename std::enable_if<(! std::is_pointer<T>::value) &&
-    traits::is_shared_native<T>::value, T>::type from_value(mrb_state *mrb, mrb_value val) {
+    traits::is_shared_native_v<T>, T>::type from_value(mrb_state *mrb, mrb_value val) {
         using ptr = typename std::add_pointer<typename std::remove_reference<T>::type>::type;
         const mrb_data_type *type = data_type<T>::value();
         conversion_check<T>(mrb, val);
@@ -291,7 +307,7 @@ namespace NM::mrb {
 
     // o is for object
     template<typename T>
-    struct param_char<T, typename std::enable_if<traits::is_shared_native<T>::value>::type> {
+    struct param_char<T, typename std::enable_if<traits::is_shared_native_v<T>>::type> {
         constexpr static const auto value = 'o';
     };
 
@@ -391,7 +407,7 @@ namespace NM::mrb {
      */
     template<typename T>
     struct conversion_helper<T,
-    typename std::enable_if<traits::is_shared_native<typename std::remove_reference<T>::type>::value>::type> {
+    typename std::enable_if<traits::is_shared_native_v<typename std::remove_reference<T>::type>>::type> {
 
         typedef typename std::remove_reference<T>::type contained_type;
 
@@ -413,7 +429,7 @@ namespace NM::mrb {
 
     template<typename T>
     struct conversion_helper<T,
-    typename std::enable_if< traits::is_shared_native<typename std::remove_pointer<T>::type>::value
+    typename std::enable_if< traits::is_shared_native_v<typename std::remove_pointer<T>::type>
     && std::is_pointer<T>::value>::type> {
         mrb_value v;
         mrb_state *mrb;
@@ -472,7 +488,7 @@ namespace NM::mrb {
      */
     template<typename T>
     struct translator {
-        static_assert(traits::is_shared_native<T>::value,
+        static_assert(traits::is_shared_native_v<T>,
                       "can only translate shared native values");
 
         static void makeClass(mrb_state *mrb) {

--- a/include/mrb_wrapper.hpp
+++ b/include/mrb_wrapper.hpp
@@ -28,11 +28,11 @@ namespace NM::mrb {
     /**
      @breif Exception for a bad conversion between an mrb type and a native type
      */
-    class BadValueConersion : std::logic_error {
+    class BadValueConversion : std::logic_error {
     public:
 
-        BadValueConersion(std::string &arg) : std::logic_error(arg) {};
-        BadValueConersion(const char *w) : std::logic_error(w) {};
+        BadValueConversion(std::string &arg) : std::logic_error(arg) {};
+        BadValueConversion(const char *w) : std::logic_error(w) {};
     };
 
 
@@ -212,7 +212,7 @@ namespace NM::mrb {
                 break;
             default:
                 auto q = std::string{"Expected a fixnum/integer, recieved a "} + data_type_string(val);
-                throw BadValueConersion{q};
+                throw BadValueConversion{q};
         }
     }
 
@@ -227,7 +227,7 @@ namespace NM::mrb {
                 break;
             default:
                 auto q =std::string{"Expected a float, recieved a "} + data_type_string(val);
-                throw BadValueConersion("Value given was not a float");
+                throw BadValueConversion("Value given was not a float");
         }
     }
 
@@ -238,7 +238,7 @@ namespace NM::mrb {
 
         if(mrb_type(val) != MRB_TT_DATA) {
             auto q = std::string{"Expected a native type, recieved "} + data_type_string(val);
-            throw BadValueConersion{q};
+            throw BadValueConversion{q};
         }
 
         if(DATA_TYPE(val) != type) {
@@ -246,7 +246,7 @@ namespace NM::mrb {
             auto real_type = data_type_string(val);
             auto expected_type = std::string{DATA_TYPE(val)->struct_name};
             auto q = std::string{"Expected native type "} + expected_type + " got " + real_type;
-            throw BadValueConersion{q};
+            throw BadValueConversion{q};
         }
     }
 

--- a/include/mrb_wrapper.hpp
+++ b/include/mrb_wrapper.hpp
@@ -182,7 +182,7 @@ namespace NM::mrb {
     typename std::enable_if<traits::is_shared_native_v<typename std::remove_pointer<T>::type> &&
     std::is_pointer<T>::value, mrb_value>::type to_value
     (mrb_state *mrb, T obj) {
-        const mrb_data_type *type = data_type<typename std::remove_pointer<T>::type>::value;
+        const mrb_data_type *type = data_type<T>::value;
         struct RClass *klass = mrb_class_get(mrb, type->struct_name);
         return mrb_obj_value(Data_Wrap_Struct(mrb, klass, type, obj));
     }
@@ -432,7 +432,7 @@ namespace NM::mrb {
         operator T() {
             // mruby's mrb_data_check_get_ptr function does not raise on error, it simply returns NULL.
             // We want it to throw an exception, which mrb_data_get_ptr does.
-            void *ptr = mrb_data_get_ptr(mrb, v, data_type<typename std::remove_reference<T>::type>::value);
+            void *ptr = mrb_data_get_ptr(mrb, v, data_type<T>::value);
             contained_type *t = static_cast<contained_type*>(ptr);
             return *t;
         }
@@ -450,7 +450,7 @@ namespace NM::mrb {
         mrb_state *mrb;
 
         operator T() {
-            void *ptr = mrb_data_get_ptr(mrb, v, data_type<typename std::remove_pointer<T>::type>::value);
+            void *ptr = mrb_data_get_ptr(mrb, v, data_type<T>::value);
             return static_cast<T>(ptr);
         }
 

--- a/include/mrb_wrapper.hpp
+++ b/include/mrb_wrapper.hpp
@@ -17,42 +17,42 @@
 
 /**
  @brief Functions, templtes, and other goodies that let us use mruby with native types
- 
+
  @discussion
  There's a lot of template metaprogramming going on in this, and it may be slightly overwhelming.
  The important thing here is to remain calm. Put on some relaxing music.
  I know I had to when writing this stuff.
  */
 namespace NM::mrb {
-    
+
     /**
      @breif Exception for a bad conversion between an mrb type and a native type
      */
     class BadValueConersion : std::logic_error {
     public:
-        
+
         BadValueConersion(std::string &arg) : std::logic_error(arg) {};
         BadValueConersion(const char *w) : std::logic_error(w) {};
     };
-    
-    
+
+
     /**
      @brief function that mruby can use in method definitions and the like
      */
     typedef mrb_value (*callable)(mrb_state*, mrb_value);
-    
-    
+
+
     /**
      @brief template to create a destructor function for some type
      @see is_data_type_struct
      */
-    
+
     template<typename T>
     void destructor_value(mrb_state *mrb, void *self) {
         T* type = reinterpret_cast<T*>(self);
         delete type;
     }
-    
+
     /**
      @brief type traits relating to shared data between C++ and Mruby
      */
@@ -64,17 +64,17 @@ namespace NM::mrb {
         struct is_data_type_struct {
             constexpr static bool value = std::is_same<const struct mrb_data_type, T>::value;
         };
-        
-        
+
+
         /**
          @brief determine if a user-defined object can be shared with MRB
-         
+
          @discussion
-         
+
          This determines if some user-defined type can be shared with MRB.
          To determine sharability in the general case, you can use is_converable,
          which determines if a given type is sharable in any case.
-         
+
          A type is sharable with MRB if it has a static member of type "const struct mrb_data_type".
          This struct will determine the type's Ruby name, as well as a deleter function
          (which should almost always be a specialization of the `destructor_value` templte).
@@ -83,7 +83,7 @@ namespace NM::mrb {
         struct is_shared_native {
             constexpr static bool value = false;
         };
-        
+
         /**
          @cond 0
          Turning off documentation here for a second.
@@ -96,7 +96,7 @@ namespace NM::mrb {
         /**
          @endcond
          */
-        
+
         /**
          Type trait which determines if this is any type we can share with MRB, including primitive types
          such as mrb_float, mrb_bool, and so on.
@@ -110,10 +110,10 @@ namespace NM::mrb {
                                            || std::is_same<std::string, T>::value
                                            || std::is_same<const char*, T>::value);
         };
-        
-        
+
+
     }
-    
+
     /**
      @brief get the mrb_data-type struct used to share this type with mruby
      @see NM::mrb::traits::is_shared_native<T>
@@ -127,28 +127,28 @@ namespace NM::mrb {
             return &(std::remove_reference<rt>::type::mrb_type);
         }
     };
-    
-    
+
+
     template<typename T>
     inline typename std::enable_if<std::is_integral<T>::value && ! std::is_same<bool, T>::value, mrb_value>::type to_value(mrb_state *mrb, T i) {
         return mrb_fixnum_value(i);
     }
-    
+
     inline mrb_value to_value(mrb_state *mrb, bool b) {
         return mrb_bool_value(b);
     }
-    
-    
+
+
     template<typename T>
     inline typename std::enable_if<std::is_floating_point<T>::value, mrb_value>::type to_value(mrb_state *mrb, T i) {
         return mrb_float_value(mrb, i);
     }
-    
+
     // No need to template this, since it only works for strings!
     inline mrb_value to_value(mrb_state *mrb, std::string s) {
         return mrb_str_new(mrb, s.c_str(), s.length());
     }
-    
+
     /**
      Convert a user-defined type into an mruby object.
      Note that we can only convert copy-constructable objects at the current moment, and cannot handle pointers at all.
@@ -162,7 +162,7 @@ namespace NM::mrb {
         T *n = new T(obj);
         return mrb_obj_value(Data_Wrap_Struct(mrb, klass, type, n));
     }
-    
+
     template<typename T>
     typename std::enable_if<traits::is_shared_native<typename std::remove_pointer<T>::type>::value &&
     std::is_pointer<T>::value, mrb_value>::type to_value
@@ -171,11 +171,11 @@ namespace NM::mrb {
         struct RClass *klass = mrb_class_get(mrb, type->struct_name);
         return mrb_obj_value(Data_Wrap_Struct(mrb, klass, type, obj));
     }
-    
+
     inline std::string native_typename(mrb_value val) {
         return std::string{"Native type: "} + DATA_TYPE(val)->struct_name;
     }
-    
+
     inline std::string data_type_string(mrb_value val) {
         switch(mrb_type(val)) {
             case MRB_TT_TRUE:
@@ -199,8 +199,8 @@ namespace NM::mrb {
                 return "Something weird";
         }
     }
-    
-    
+
+
     template<typename T>
     typename std::enable_if<std::is_integral<T>::value, T>::type from_value(mrb_state *mrb, mrb_value val) {
         switch(mrb_type(val)) {
@@ -215,7 +215,7 @@ namespace NM::mrb {
                 throw BadValueConersion{q};
         }
     }
-    
+
     template<typename T>
     typename std::enable_if<std::is_floating_point<T>::value, T>::type from_value(mrb_state *mrb, mrb_value val) {
         switch(mrb_type(val)) {
@@ -230,17 +230,17 @@ namespace NM::mrb {
                 throw BadValueConersion("Value given was not a float");
         }
     }
-    
+
     template<typename T>
     typename std::enable_if<traits::is_shared_native<typename std::remove_reference<typename std::remove_pointer<T>::type>::type>::value>::type conversion_check(mrb_state *mrb, mrb_value val) {
         using Ti = typename std::remove_reference<typename std::remove_pointer<T>::type>::type;
         auto type = data_type<T>::value();
-        
+
         if(mrb_type(val) != MRB_TT_DATA) {
             auto q = std::string{"Expected a native type, recieved "} + data_type_string(val);
             throw BadValueConersion{q};
         }
-        
+
         if(DATA_TYPE(val) != type) {
             // Super expensive operation, but this just crashes the engine anyway, so who cares
             auto real_type = data_type_string(val);
@@ -249,8 +249,8 @@ namespace NM::mrb {
             throw BadValueConersion{q};
         }
     }
-    
-    
+
+
     template<typename T>
     typename std::enable_if<std::is_pointer<T>::value &&
     traits::is_shared_native<typename std::remove_pointer<T>::type>::value, T>::type
@@ -260,7 +260,7 @@ namespace NM::mrb {
         void *ptr = mrb_data_check_get_ptr(mrb, val, type);
         return static_cast<T>(ptr);
     }
-    
+
     template<typename T>
     typename std::enable_if<(! std::is_pointer<T>::value) &&
     traits::is_shared_native<T>::value, T>::type from_value(mrb_state *mrb, mrb_value val) {
@@ -274,12 +274,12 @@ namespace NM::mrb {
         // We than dereference this ptr to cause the copy constructor to be invoked
         return * static_cast<ptr>(p);
     }
-    
-    
-    
-    
 
-    
+
+
+
+
+
     /**
      mruby's mrb_get_args function takes a printf-style format string to specify argument types
      This struct allows us to get the format specifier for a single given type.
@@ -289,36 +289,36 @@ namespace NM::mrb {
     template<typename T, typename Extern = void>
     struct param_char {
     };
-    
+
     // o is for object
     template<typename T>
     struct param_char<T, typename std::enable_if<traits::is_shared_native<T>::value>::type> {
         constexpr static const auto value = 'o';
     };
-    
+
     // f is for float
     template<typename T>
     struct param_char<T, typename std::enable_if<std::is_floating_point<T>::value>::type> {
         constexpr static const auto value = 'f';
     };
-    
+
     // i is for integer
     template<typename T>
     struct param_char<T, typename std::enable_if<std::is_integral<T>::value && ! std::is_same<bool, T>::value>::type> {
         constexpr static auto value = 'i';
     };
-    
+
     // b is for bool
     template<typename T>
     struct param_char<T, typename std::enable_if<std::is_same<bool, T>::value>::type> {
         constexpr static auto value = 'b';
     };
-    
-    
-    
+
+
+
     /**
      Obtain the printf-style format specifier required by mrg_get_args.
-     
+
      We already defined templates to determine the proper character for arbitrary types, so this
      function returns the entire format string. It does so by folding over the types—
      Take the first type, get its format specifier character, add the string that specifies the rest of
@@ -328,64 +328,64 @@ namespace NM::mrb {
     struct param_format_string {
         static const char value[];
     };
-    
+
     template<typename ...Args>
     const char param_format_string<Args...>::value[] = {(param_char<typename std::remove_reference<Args>::type>::value)..., '\0'};
-    
+
     /**
      Defines a struct that assists in conversion of types from mruby types to C++ types.
      */
     template<typename T, typename U = void>
     struct conversion_helper {
     };
-    
-    
+
+
     // Specialization for floating point types
     template<typename T>
     struct conversion_helper<T, typename std::enable_if<std::is_floating_point<T>::value>::type> {
         mrb_float d;
         mrb_state *mrb;
-        
+
         operator T() {
             return static_cast<T>(d);
         }
-        
+
         void* to_ptr() {
             return (void *) &d;
         }
-        
+
     };
-    
+
     // Specialization for integral types
     template<typename T>
     struct conversion_helper<T,
     typename std::enable_if<std::is_integral<T>::value>::type> {
         mrb_int i;
         mrb_state *mrb;
-        
+
         operator T() {
             return static_cast<T>(i);
         }
-        
+
         void* to_ptr() {
             return (void *) &i;
         }
     };
-    
+
     // Specialization for strings
     template<> struct conversion_helper<std::string> {
         char *ptr;
         mrb_state *mrb;
-        
+
         operator std::string() {
             return ptr;
         }
-        
+
         void* to_ptr() {
             return (void *) &ptr;
         }
     };
-    
+
     /**
      Specialization of user-defined types.
      This works for reference types and value types, pointer types are handled seperately
@@ -393,12 +393,12 @@ namespace NM::mrb {
     template<typename T>
     struct conversion_helper<T,
     typename std::enable_if<traits::is_shared_native<typename std::remove_reference<T>::type>::value>::type> {
-        
+
         typedef typename std::remove_reference<T>::type contained_type;
-        
+
         mrb_value v;
         mrb_state *mrb;
-        
+
         operator T() {
             // mruby's mrb_data_check_get_ptr function does not raise on error, it simply returns NULL.
             // We want it to throw an exception, which mrb_data_get_ptr does.
@@ -406,38 +406,38 @@ namespace NM::mrb {
             contained_type *t = static_cast<contained_type*>(ptr);
             return *t;
         }
-        
+
         void* to_ptr() {
             return (void *) &v;
         }
     };
-    
+
     template<typename T>
     struct conversion_helper<T,
     typename std::enable_if< traits::is_shared_native<typename std::remove_pointer<T>::type>::value
     && std::is_pointer<T>::value>::type> {
         mrb_value v;
         mrb_state *mrb;
-        
+
         operator T() {
             void *ptr = mrb_data_get_ptr(mrb, v, data_type<typename std::remove_pointer<T>::type>::value());
             return static_cast<T>(ptr);
         }
-        
+
         void* to_ptr() {
             return &v;
         }
     };
-    
-    
+
+
     /**
      @brief template to help us bind native types to Ruby.
-     
+
      @discussion
-     
+
      This template class uses a variety of increasingly horrifying metaprogramming techniques to
      provide a clean(ish) user interface to share C++ classes to Ruby.
-     
+
      Let's say I have a type Vector, which has some methods.
      I can write a "binder function" which takes in an `mrb_state*`.
      I want to make that function bind a lot of methods into `mrb_state` so I can use my Vector type from ruby.
@@ -475,15 +475,15 @@ namespace NM::mrb {
     struct translator {
         static_assert(traits::is_shared_native<T>::value,
                       "can only translate shared native values");
-        
+
         static void makeClass(mrb_state *mrb) {
             mrb_define_class(mrb, data_type<T>::value()->struct_name, mrb->object_class);
         }
-        
+
         static struct RClass* getClass(mrb_state *mrb) {
             return mrb_class_get(mrb, data_type<T>::value()->struct_name);
         }
-        
+
         template<typename ...Args>
         struct constructor {
             static void bind(mrb_state *mrb) {
@@ -491,7 +491,7 @@ namespace NM::mrb {
                 mrb_define_class_method(mrb,
                                         getClass(mrb), "new", f, MRB_ARGS_REQ(sizeof...(Args)));
             }
-            
+
         private:
             static mrb_value val(mrb_state *mrb, mrb_value self) {
                 std::string format = param_format_string<Args...>::value;
@@ -501,19 +501,19 @@ namespace NM::mrb {
                 T* constructed = make_call(t, std::index_sequence_for<Args...>{});
                 return mrb_obj_value(Data_Wrap_Struct(mrb, getClass(mrb), data_type<T>::value(), (void *) constructed));
             }
-            
+
             template<class Tuple, std::size_t... indexes>
             static T* make_call(Tuple &t, std::index_sequence<indexes...>) {
                 return new T(std::get<indexes>(t)...);
             }
         };
-        
+
         template<typename Ret, typename ...Args>
         struct method {
             typedef Ret(T::*funcType)(Args...);
             typedef Ret(T::*constFuncType)(Args...) const;
-            
-            
+
+
             template<funcType func>
             struct binder{
                 static void bind(mrb_state *mrb, std::string name) {
@@ -521,7 +521,7 @@ namespace NM::mrb {
                     mrb_define_method(mrb,
                                       getClass(mrb), name.c_str(), f, sizeof...(Args));
                 }
-                
+
             private:
                 static mrb_value method(mrb_state *mrb, mrb_value self) {
                     std::string format = param_format_string<Args...>::value;
@@ -533,13 +533,13 @@ namespace NM::mrb {
                     Ret re = make_call(s, func, t, std::index_sequence_for<Args...>{});
                     return to_value(mrb, re);
                 }
-                
+
                 template<class Tuple, std::size_t... indexes>
                 static Ret make_call(T *self, funcType f, Tuple &t, std::index_sequence<indexes...>) {
                     return (self->*f)(std::get<indexes>(t)...);
                 }
             };
-            
+
             template<constFuncType func>
             struct const_binder {
                 static void bind(mrb_state *mrb, std::string name) {
@@ -547,7 +547,7 @@ namespace NM::mrb {
                     mrb_define_method(mrb,
                                       getClass(mrb), name.c_str(), f, sizeof...(Args));
                 }
-                
+
             private:
                 static mrb_value method(mrb_state *mrb, mrb_value self) {
                     std::string format = param_format_string<Args...>::value;
@@ -559,7 +559,7 @@ namespace NM::mrb {
                     Ret re = make_call(s, func, t, std::index_sequence_for<Args...>{});
                     return to_value(mrb, re);
                 }
-                
+
                 /**
                  Use parameter pack expansion and an index sequence paramater to call the function
                  */
@@ -567,16 +567,16 @@ namespace NM::mrb {
                 static Ret make_call(T *self, constFuncType f, Tuple &t, std::index_sequence<indexes...>) {
                     return (self->*f)(std::get<indexes>(t)...);
                 }
-                
+
             };
-            
+
         };
-        
+
     protected:
         /**
          Given a tuple of mrb_conversion_helpers, sets each one of their mrb members to the current mrb_state.
          We need this to do some value conversions.
-         
+
          Uses that same nasty static paramater pack shit the other things use
          */
         template<class Tuple, std::size_t... indexes>
@@ -587,7 +587,7 @@ namespace NM::mrb {
             // C++ parameter pack syntax: It's... It's not very good
             (void) swallow{0, (void (std::get<indexes>(t).mrb = mrb), 0)...};
         }
-        
+
         /**
          Nasty paramater packs shit to properly expand this into varargs. So gross.
          */
@@ -599,7 +599,7 @@ namespace NM::mrb {
             mrb_get_args(mrb, format.c_str(), (std::get<indexes>(t).to_ptr())...);
         }
     };
-    
+
 }
 
 #endif /* mrb_wrapper_h */

--- a/include/vector.hpp
+++ b/include/vector.hpp
@@ -4,7 +4,8 @@
 #include <stdint.h>
 #include <cmath>
 #include <sstream>
-#include <mrb_wrapper.hpp>
+#include <mruby.h>
+#include <mruby/data.h>
 
 namespace NM {
     

--- a/src/vector.cpp
+++ b/src/vector.cpp
@@ -1,4 +1,5 @@
 #include "vector.hpp"
+#include "mrb_wrapper.hpp"
 
 namespace NM {
     

--- a/test/mrb_wrapper.cpp
+++ b/test/mrb_wrapper.cpp
@@ -15,3 +15,36 @@ TEST_CASE("param_char", "[mrb_wrapper]") {
 		REQUIRE((param_char<NM::Vector>::value == 'o'));
 	}
 }
+
+TEST_CASE("param_format_string", "[mrb_wrapper]") {
+	REQUIRE((std::string("fibo") == param_format_string<float, int, bool, NM::Vector>::value));
+	REQUIRE((std::string("") == param_format_string<>::value));
+}
+
+TEST_CASE("to_value", "[mrb_wrapper]") {
+    mrb_state *mrb = mrb_open();
+
+	SECTION("positive integer") {
+		mrb_value v = to_value(mrb, 1);
+		REQUIRE(data_type_string(v) == "fixnum");
+		REQUIRE(from_value<int>(mrb, v) == 1);
+	}
+
+	SECTION("negative integer") {
+		mrb_value v = to_value(mrb, -15);
+		REQUIRE(data_type_string(v) == "fixnum");
+		REQUIRE(from_value<int>(mrb, v) == -15);
+	}
+
+	SECTION("positive short") {
+		mrb_value v = to_value(mrb, static_cast<short>(123));
+		REQUIRE(data_type_string(v) == "fixnum");
+		REQUIRE(from_value<short>(mrb, v) == 123);
+	}
+
+	SECTION("negative short") {
+		mrb_value v = to_value(mrb, static_cast<short>(-123));
+		REQUIRE(data_type_string(v) == "fixnum");
+		REQUIRE(from_value<short>(mrb, v) == -123);
+	}
+}

--- a/test/mrb_wrapper.cpp
+++ b/test/mrb_wrapper.cpp
@@ -47,4 +47,14 @@ TEST_CASE("to_value", "[mrb_wrapper]") {
 		REQUIRE(data_type_string(v) == "fixnum");
 		REQUIRE(from_value<short>(mrb, v) == -123);
 	}
+
+	SECTION("bool") {
+		mrb_value v = to_value(mrb, true);
+		REQUIRE(data_type_string(v) == "bool");
+		REQUIRE(from_value<bool>(mrb, v) == true);
+
+		v = to_value(mrb, false);
+		REQUIRE(data_type_string(v) == "bool");
+		REQUIRE(from_value<bool>(mrb, v) == false);
+	}
 }

--- a/test/mrb_wrapper.cpp
+++ b/test/mrb_wrapper.cpp
@@ -1,0 +1,17 @@
+#include "catch.hpp"
+#include "mrb_wrapper.hpp"
+#include "vector.hpp"
+
+using namespace NM::mrb;
+
+TEST_CASE("param_char", "[mrb_wrapper]") {
+	SECTION("primitive types") {
+		REQUIRE((param_char<float>::value == 'f'));
+		REQUIRE((param_char<int>::value == 'i'));
+		REQUIRE((param_char<bool>::value == 'b'));
+	}
+
+	SECTION("shared natives") {
+		REQUIRE((param_char<NM::Vector>::value == 'o'));
+	}
+}

--- a/test/vector_test.cpp
+++ b/test/vector_test.cpp
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 #include "vector.hpp"
+#include "mrb_wrapper.hpp"
 #include <mruby/compile.h>
 
 TEST_CASE("Vector constructs properly with arguments") {


### PR DESCRIPTION
Same as #1, minus 97bf435. Instead, I've included 50fecbe, which tries to get rid of the code duplication between `const_binder` and `binder`.